### PR TITLE
Fetch transactor peer by region

### DIFF
--- a/transactors.tf
+++ b/transactors.tf
@@ -86,10 +86,26 @@ resource "aws_security_group" "datomic" {
   }
 }
 
+# transactor ami
+data "aws_ami" "transactor" {
+  most_recent = true
+  owners      = ["754685078599"]
+
+  filter {
+    name   = "name"
+    values = ["datomic-transactor-*"]
+  }
+
+  filter {
+    name   = "virtualization-type"
+    values = ["${var.transactor_instance_virtualization_type}"]
+  }
+}
+
 # transactor launch config
 resource "aws_launch_configuration" "transactor" {
   name_prefix          = "${var.system_name}-transactor-"
-  image_id             = "${var.transactor_ami}"
+  image_id             = "${data.aws_ami.transactor.id}"
   instance_type        = "${var.transactor_instance_type}"
   iam_instance_profile = "${aws_iam_instance_profile.transactor.name}"
   security_groups      = ["${aws_security_group.datomic.name}"]

--- a/variables.tf
+++ b/variables.tf
@@ -28,16 +28,16 @@ variable "peers" {
   default = "1"
 }
 
-variable "transactor_ami" {
-  default = "ami-c942d9f3" # datomic ami (ap-southeast-2)
-}
-
 variable "transactor_availability_zones" {
   default = ["ap-southeast-2a", "ap-southeast-2b", "ap-southeast-2c"]
 }
 
 variable "transactor_instance_type" {
   default = "c3.large"
+}
+
+variable "transactor_instance_virtualization_type" {
+  default = "hvm"
 }
 
 variable "transactors" {


### PR DESCRIPTION
Terraform 0.7.0 introduced a new feature for fetching AMIs via AWS
queries. So, we can leverage this feature to remove the hard-coded AMI
code and query about the right AMI for a given region/virtualization
type.

This commit just update transactor AMI. The same technique could be done
for peers, given they are just barebone ubuntu images, but since peers
are a little more custom-made I prefer to do that on another commit if
necessary.
